### PR TITLE
Find undocumented round info fields

### DIFF
--- a/docs/ai-implementation-guide.md
+++ b/docs/ai-implementation-guide.md
@@ -121,9 +121,11 @@ Your AI implements three methods, each receiving **read‑only** views:
 
 ## Available Game State
 
-### `CurrentRoundInfo` (high‑level fields)
+### `CurrentRoundInfo` (high-level fields)
+- `game_id: i64` — useful for fetching cached `GameHistory`/`RoundMemory`
 - `player_seat: i16` (0–3), `dealer_pos: i16` (0–3)  
 - `current_round: i16` (1–26), `hand_size: u8`, `game_state: GameState`
+- `hand: Vec<Card>` — remaining cards in your hand after removing plays already recorded
 - `bids: Vec<Option<u8>>`, `trump: Option<Trump>`
 - `trick_no: i16` (1..=hand_size)  
 - `current_trick_plays: Vec<(i16, Card)>`


### PR DESCRIPTION
Document `game_id` and `hand` fields in `CurrentRoundInfo` within the AI implementers guide.

These fields are exposed in the code but were not previously listed in the `CurrentRoundInfo` section of the `ai-implementation-guide.md`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a9b27044-d170-467d-bcbc-b6eadeec2774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a9b27044-d170-467d-bcbc-b6eadeec2774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `game_id` and `hand` to `CurrentRoundInfo` docs and normalizes the section heading formatting.
> 
> - **Docs (`docs/ai-implementation-guide.md`)**:
>   - **`CurrentRoundInfo`**:
>     - Add `game_id: i64` and `hand: Vec<Card>` to the listed fields.
>     - Normalize heading text to "high-level".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92e4d95d9ffe4c0ecc1b143d188cd502a1bfd7c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->